### PR TITLE
Local config can override by name to bring a repo above system config

### DIFF
--- a/src/ComposerJson.php
+++ b/src/ComposerJson.php
@@ -255,17 +255,17 @@ class ComposerJson extends AbstractClass
         $packagistOrgDisabled = false;
 
         if (array_key_exists('repositories', $data)) {
-            foreach ($data['repositories'] as $repository) {
+            foreach ($data['repositories'] as $key => $repository) {
                 if (array_key_exists('packagist.org', $repository) && $repository['packagist.org'] === false) {
                     $packagistOrgDisabled = true;
                     continue;
                 }
 
-                $this->repositories[] = new Repository($repository);
+                $this->repositories[$key] = new Repository($repository);
             }
         }
 
-        if ($packagistOrgDisabled === false) {
+        if ($packagistOrgDisabled === false && !isset($this->repositories['packagist.org'])) {
             $this->repositories['packagist.org'] = new Repository([
                 'type' => 'composer',
                 'url' => 'https?://repo.packagist.org',


### PR DESCRIPTION
I've made changes to make it work accordingly to [this test](https://github.com/composer/composer/blob/2a13bb2649151932407aae1a37a356179b1f5199/tests/Composer/Test/ConfigTest.php#L95-L106).

Here is a payload for the test:
```js
"repositories": {
    "packagist.org": {
        "type": "composer",
        "url": "http://packagistnew.org"
    },
    "example.com": {
        "type": "composer",
        "url": "http://example.com"
    }
},
```

If `packagist.org` key already exists - default repository wouldn't be added to the list.