### PR TITLE
Revert addition of allow_ssl_downgrade flag

### DIFF
--- a/src/Json/Repository.php
+++ b/src/Json/Repository.php
@@ -30,11 +30,6 @@ class Repository extends AbstractClass
     protected $options;
 
     /**
-     * @var bool
-     */
-    protected $allowSslDowngrade;
-
-    /**
      * @var ComposerJson|null
      */
     protected $package;
@@ -49,7 +44,6 @@ class Repository extends AbstractClass
         $this->type = (array_key_exists('type', $data) ? $data['type'] : '');
         $this->url = (array_key_exists('url', $data) ? $data['url'] : '');
         $this->options = (array_key_exists('options', $data) ? $data['options'] : []);
-        $this->allowSslDowngrade = (array_key_exists('allow_ssl_downgrade', $data) ? $data['allow_ssl_downgrade'] : false);
 
         $this->package = (array_key_exists('package', $data) ? new ComposerJson($data['package']) : null);
     }
@@ -79,16 +73,6 @@ class Repository extends AbstractClass
     public function getOptions() : array
     {
         return $this->options;
-    }
-
-    /**
-     * Get if ssl may be downgraded for this repository.
-     * @see https://github.com/composer/composer/blob/0fe200d6d950b0774688713be3153bb410eb70b8/src/Composer/Repository/ComposerRepository.php#L87-L89
-     * @return bool
-     */
-    public function isSslDowngradeAllowed() : bool
-    {
-        return $this->allowSslDowngrade;
     }
 
     /**


### PR DESCRIPTION
This PR reverts commit d42b68c560bf561298547bc1079b3141c87f148a because this flag could appear only in `composer` repository type. More details in #6 

This change was not released in any stable releases so I'm just removing.